### PR TITLE
[FIX] Fix display of the contributors file

### DIFF
--- a/bin/format_release_note.py
+++ b/bin/format_release_note.py
@@ -142,7 +142,7 @@ def write_authors(authors, milestone_title):
 
     with open("{}-authors.md".format(milestone_title), "w",
               encoding="utf8") as authors_file:
-        authors_file.write("## Contributors\n")
+        authors_file.write("## Contributors\n\n")
         for author in sorted(list(authors), key=str.casefold):
             authors_file.write("- {}\n".format(author))
 


### PR DESCRIPTION
Skip one line between the "Contributors" title and the actual list of contributors, for the display to be correct.