### PR TITLE
[FIX] Write authors file if the option is specified

### DIFF
--- a/bin/format_release_note.py
+++ b/bin/format_release_note.py
@@ -211,7 +211,7 @@ def write_final_release_note(pull_requests, milestone_title,
                                            link))
 
 
-def execute(input_file, authors, show_pr_nb, excl_labels, incl_labels,
+def execute(input_file, write_authors, show_pr_nb, excl_labels, incl_labels,
             excl_words, incl_words):
     with open("{}".format(input_file), "r") as json_file:
         data = json.load(json_file)
@@ -399,7 +399,7 @@ def execute(input_file, authors, show_pr_nb, excl_labels, incl_labels,
     for word, counter in excluded_word_counters.items():
         print("\t- '{}': {}".format(word, counter))
 
-    if authors:
+    if write_authors:
         write_authors(authors, milestone_title)
     write_final_release_note(pull_requests, milestone_title,
                              included_pull_requests,


### PR DESCRIPTION
Fixes an issue introduced when the execute() function was added to the formatter. The boolean that decided whether the file should be written was overwritten with the set containing the list of contributors, which had always at least one entry.