### PR TITLE
[FIX] Fix ambiguity between boolean and method name

### DIFF
--- a/bin/format_release_note.py
+++ b/bin/format_release_note.py
@@ -211,7 +211,7 @@ def write_final_release_note(pull_requests, milestone_title,
                                            link))
 
 
-def execute(input_file, write_authors, show_pr_nb, excl_labels, incl_labels,
+def execute(input_file, export_authors, show_pr_nb, excl_labels, incl_labels,
             excl_words, incl_words):
     with open("{}".format(input_file), "r") as json_file:
         data = json.load(json_file)
@@ -399,7 +399,7 @@ def execute(input_file, write_authors, show_pr_nb, excl_labels, incl_labels,
     for word, counter in excluded_word_counters.items():
         print("\t- '{}': {}".format(word, counter))
 
-    if write_authors:
+    if export_authors:
         write_authors(authors, milestone_title)
     write_final_release_note(pull_requests, milestone_title,
                              included_pull_requests,


### PR DESCRIPTION
The name of the boolean used to decide whether the authors list should be written was the name as the method used to actually write that list into a file.