### PR TITLE
Add basic demo with PRs' number displayed

### DIFF
--- a/demo/basic-authors-pr-nb/Demo Milestone-authors.md
+++ b/demo/basic-authors-pr-nb/Demo Milestone-authors.md
@@ -1,0 +1,3 @@
+## Contributors
+
+- cbentejac

--- a/demo/basic-authors-pr-nb/Demo Milestone-release-note.md
+++ b/demo/basic-authors-pr-nb/Demo Milestone-release-note.md
@@ -1,0 +1,19 @@
+# Release note
+
+## Demo Milestone
+
+- Corrected usage of github-generate-release-note [PR #19](https://github.com/cbentejac/github-generate-release-note/pull/19)
+- Add demo with basic parameters and list of authors [PR #18](https://github.com/cbentejac/github-generate-release-note/pull/18)
+- [FIX] Fix ambiguity between boolean and method name [PR #17](https://github.com/cbentejac/github-generate-release-note/pull/17)
+- Add a demo with default parameters [PR #16](https://github.com/cbentejac/github-generate-release-note/pull/16)
+- [FIX] Write authors file if the option is specified [PR #15](https://github.com/cbentejac/github-generate-release-note/pull/15)
+- [FIX] Fix display of the contributors file [PR #13](https://github.com/cbentejac/github-generate-release-note/pull/13)
+- [FIX] Replace single quotes by double ones when possible [PR #12](https://github.com/cbentejac/github-generate-release-note/pull/12)
+- [FIX] Fix display of options in bin/README.md [PR #11](https://github.com/cbentejac/github-generate-release-note/pull/11)
+- Update README.md [PR #10](https://github.com/cbentejac/github-generate-release-note/pull/10)
+- Add README.md in the "bin" directory [PR #8](https://github.com/cbentejac/github-generate-release-note/pull/8)
+- Add final github-generate-release-note script [PR #5](https://github.com/cbentejac/github-generate-release-note/pull/5)
+- Add execute() functions that are directly called in main() [PR #3](https://github.com/cbentejac/github-generate-release-note/pull/3)
+- Make the "bin" directory a Python module [PR #4](https://github.com/cbentejac/github-generate-release-note/pull/4)
+- Request and export all PRs of a milestone to a JSON file [PR #1](https://github.com/cbentejac/github-generate-release-note/pull/1)
+- Format a JSON file containing the list of PRs into a markdown release note [PR #2](https://github.com/cbentejac/github-generate-release-note/pull/2)

--- a/demo/basic-authors-pr-nb/README.md
+++ b/demo/basic-authors-pr-nb/README.md
@@ -1,0 +1,10 @@
+# Demo
+
+Release note generated with a list of contributors on the side. The pull request number is directly shown, and it is not necessary to hover over the link or to click it to see which pull request is referred to.
+
+_Any file in this directory beside this README.md is a result of the command below._
+
+```
+./github-generate-release-note.py -o cbentejac -r github-generate-release-note -m "Demo Milestone" --authors --pr-nb
+```
+

--- a/demo/basic-authors/Demo Milestone-release-note.md
+++ b/demo/basic-authors/Demo Milestone-release-note.md
@@ -2,6 +2,8 @@
 
 ## Demo Milestone
 
+- Corrected usage of github-generate-release-note [PR](https://github.com/cbentejac/github-generate-release-note/pull/19)
+- Add demo with basic parameters and list of authors [PR](https://github.com/cbentejac/github-generate-release-note/pull/18)
 - [FIX] Fix ambiguity between boolean and method name [PR](https://github.com/cbentejac/github-generate-release-note/pull/17)
 - Add a demo with default parameters [PR](https://github.com/cbentejac/github-generate-release-note/pull/16)
 - [FIX] Write authors file if the option is specified [PR](https://github.com/cbentejac/github-generate-release-note/pull/15)

--- a/demo/basic/Demo Milestone-release-note.md
+++ b/demo/basic/Demo Milestone-release-note.md
@@ -2,6 +2,8 @@
 
 ## Demo Milestone
 
+- Corrected usage of github-generate-release-note [PR](https://github.com/cbentejac/github-generate-release-note/pull/19)
+- Add demo with basic parameters and list of authors [PR](https://github.com/cbentejac/github-generate-release-note/pull/18)
 - [FIX] Fix ambiguity between boolean and method name [PR](https://github.com/cbentejac/github-generate-release-note/pull/17)
 - Add a demo with default parameters [PR](https://github.com/cbentejac/github-generate-release-note/pull/16)
 - [FIX] Write authors file if the option is specified [PR](https://github.com/cbentejac/github-generate-release-note/pull/15)


### PR DESCRIPTION
- Update all the existing demos (regenerated with the latest list of pull requests)
- Add a demo that is identical to "basic-authors" but changes the display of the pull requests' link: instead of having just "PR" containing the link, the number of the pull request is also displayed, as "PR #XX".