### PR TITLE
Add option to highlight the major features using labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ pip install requests
 ```
 ./github-generate-release-note.py [-h] -o OWNER -r REPO -m MILESTONE
                                 [-s {created-desc,created-asc,comments-desc,comments-asc,updated-desc,updated-asc,relevance-desc}]
-                                [-t TOKEN] [--authors] [--pr-nb] [--label-exclude EXCLUDE [EXCLUDE ...]]
+                                [-t TOKEN] [--authors] [--pr-nb] [--highlights LABEL [LABEL ...]]
+                                [--label-exclude EXCLUDE [EXCLUDE ...]]
                                 [--label-include INCLUDE [INCLUDE ...]]
                                 [--word-exclude WORD_EXCLUDE [WORD_EXCLUDE ...]]
                                 [--word-include WORD_INCLUDE [WORD_INCLUDE ...]] [--save]
@@ -48,6 +49,8 @@ pip install requests
 `--authors`: save the list of pull requests authors in a dedicated file, instead of only having them in the release note
 
 `--pr-nb`: include the merged pull requests' number with their link
+
+`--highlights`: labels that need to be highlighted in the release note, for example because the pull request tagged with that label was a major contribution; several labels can be provided at once, either together as "--highlights label1,label2" or "--highlights label1 label2". all labels provided with this option will be added to a specific section, with no way to distinguish them from each other.
 
 `--label-exclude EXCLUDE [EXCLUDE ...]`: labels that will be excluded from the release note and dumped in a dedicated file instead; several labels can be provided at once, either concatenated like "--label-exclude label1,label2" to dump them in the same file, or separated like "--label-exclude label1 label2" to dump them in separate files. a pull request does not need to have all the labels from a concatenated input to be excluded, one is enough. labels are case-sensitive. label exclusion takes precedence over word exclusion.
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -61,7 +61,8 @@ If they are included, they will be separated from the main list and displayed in
 ### Usage
 
 ```
-./format_release_note.py [-h] [-i INPUT] [--authors] [--pr-nb] [--label-exclude EXCLUDE [EXCLUDE ...]]
+./format_release_note.py [-h] [-i INPUT] [--authors] [--pr-nb] [--highlights LABEL [LABEL ...]]
+                         [--label-exclude EXCLUDE [EXCLUDE ...]]
                          [--label-include INCLUDE [INCLUDE ...]] [--word-exclude WORD_EXCLUDE [WORD_EXCLUDE ...]]
                          [--word-include WORD_INCLUDE [WORD_INCLUDE ...]]
 ```
@@ -73,6 +74,8 @@ If they are included, they will be separated from the main list and displayed in
 `--authors`: save the list of pull requests authors in a dedicated file, instead of only having them in the release note
 
 `--pr-nb`: include the merged pull requests' number with their link
+
+`--highlights`: labels that need to be highlighted in the release note, for example because the pull request tagged with that label was a major contribution; several labels can be provided at once, either together as "--highlights label1,label2" or "--highlights label1 label2". all labels provided with this option will be added to a specific section, with no way to distinguish them from each other.
 
 `--label-exclude EXCLUDE [EXCLUDE ...]`: labels that will be excluded from the release note and dumped in a dedicated file instead; several labels can be provided at once, either concatenated like "--label-exclude label1,label2" to dump them in the same file, or separated like "--label-exclude label1 label2" to dump them in separate files. a pull request does not need to have all the labels from a concatenated input to be excluded, one is enough. labels are case-sensitive. label exclusion takes precedence over word exclusion.
 

--- a/github-generate-release-note.py
+++ b/github-generate-release-note.py
@@ -57,6 +57,15 @@ def setup_arg_parser():
         default=False,
         help="include the merged pull requests' number with their link")
     arg_parser.add_argument(
+        "--highlights",
+        nargs="+",
+        help="""labels that need to be highlighted in the release note, for
+                example because the pull request tagged with that label was a
+                major contribution; several labels can be provided at once, either
+                together as "--highlights label1,label2" or "--highlights label 1
+                label2". all labels provided with this option will be added to a
+                specific section, with no way to distinguish them from each other.""")
+    arg_parser.add_argument(
         "--label-exclude",
         dest="exclude",
         nargs="+",
@@ -137,9 +146,9 @@ def main():
         repo_param, milestone_param, sorting_param, args.token, json_file)
 
     format_release_note.execute(json_file, args.authors, args.pr_nb,
-                                args.exclude, args.include, args.word_exclude,
-                                args.word_include)
-    
+                                args.highlights, args.exclude, args.include,
+                                args.word_exclude, args.word_include)
+
     # Remove the JSON file containing the response from GitHub
     if not args.save:
         os.remove(json_file)


### PR DESCRIPTION
The `--highlights` option is added to group all the pull requests tagged with specified labels into a separated "Main features" section, which will be displayed before all the other sections.